### PR TITLE
Added compatibility with Bob's Logistics Belt Overhaul

### DIFF
--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -30,6 +30,15 @@ local function create_ancient_drill_technology()
         table.insert(technology.unit.ingredients, {"electromagnetic-science-pack", 2})
 		table.insert(technology.unit.ingredients, {"metallurgic-science-pack", 2})
     end
+
+    if mods["boblogistics"] and settings.startup["bobmods-logistics-beltoverhaul"].value == true then
+        for i, t in pairs(technology.prerequisites) do
+            if t == "turbo-transport-belt" then
+                table.remove(technology.prerequisites, i)
+                table.insert(technology.prerequisites, "logistics-4")
+            end            
+        end
+    end
     
     return technology
 end


### PR DESCRIPTION
When having the space-age expansion installed, a dependency for Ancient Drill is turbo-belt (I think this is reasonable). But with bob's logistics installed and the belt overhaul activated, this technology is moved to logistics-4.
I do not know if my implementation is efficient, since I'm new to Lua, but it does its job.